### PR TITLE
Add links to own docs.rs and tuple_map crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Map Tuple
 
-Provides traits to allow `map()`ing specific elements of a tuple. See docs for details.
+Provides traits to allow `map()`ing specific elements of a tuple. See
+[docs](https://crates.io/crates/map_tuple) for details.
 
-This differs from the `tuple-map` crate in that the elements of the tuple don't have to be of the
+This differs from the [tuple-map](https://crates.io/crates/tuple_map) crate in
+that the elements of the tuple don't have to be of the
 same type, and can be mapped to unique different types.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@
 //! assert_eq!(tuple, ("0".to_string(), Some(1.0f32), 2i32, 3i64, true));
 //! ```
 //!
+//! If you want to `map()` entire tuples of the same type like `(T, T, T)`,
+//! use [tuple_map](https://crates.io/crates/tuple_map).
+//!
 //! # Features
 //! Because rust doesn't allow reasoning about tuples generically, each tuple trait has to be
 //! implemented for each size of tuple explicitly. This crate provides 4 levels of tuple sizing


### PR DESCRIPTION
More discoverability and less confusion is good. I also opened an equivalent [pull request](https://github.com/kngwyu/tuple-map/pull/1)  for that crate